### PR TITLE
Packaging: remove python(abi) = 3.6 deps for python3-leapp rpm

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -141,7 +141,12 @@ Requires: findutils
 
 %package -n python3-%{name}
 Summary: %{summary}
-%{?system_python_abi}
+# comment out the python abi requirement. we need to discuss this one later.
+# currently, with the generated python(abi) = 3.6 it's not possible to preserve
+# the rpm on RHEL 9 system. let's talk about consequences of the removal later
+# and how to deal with possible problems
+# %%{?system_python_abi}
+%{?python_disable_dependency_generator}
 %{?python_provide:%python_provide python3-%{name}}
 
 BuildRequires:  python3-devel

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -146,7 +146,8 @@ Summary: %{summary}
 # the rpm on RHEL 9 system. let's talk about consequences of the removal later
 # and how to deal with possible problems
 # %%{?system_python_abi}
-%{?python_disable_dependency_generator}
+# %%{?python_disable_dependency_generator}
+%define __provides_exclude_from ^.*$
 %{?python_provide:%python_provide python3-%{name}}
 
 BuildRequires:  python3-devel


### PR DESCRIPTION
comment out the python abi requirement. we need to discuss this one later.
currently, with the generated python(abi) = 3.6 it's not possible to preserve
the rpm on RHEL 9 system. let's talk about consequences of the removal later